### PR TITLE
Adds author information for OA website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,11 @@ url:
 # then add in the baseurl here, like this: "/repository-name"
 baseurl: ""
 
+# Author information for the RSS feeds. If `author` is not listed
+# on the front-matter of each post, it will use this as the default.
+# https://github.com/jekyll/jekyll-feed#author-information
+author: Somesh Verma
+
 #
 # !! You don't need to change any of the configuration flags below !!
 #

--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ footer-links:
   email:
   facebook:
   flickr:
-  github: https://github.com/1someshverma
+  github: 1someshverma
   instagram:
   linkedin:
   pinterest:


### PR DESCRIPTION
Also fixes the gh footer link.
This way, your posts will be fetched with the right author information, instead of a blank string that then Open Astronomy aggregator can display it properly.